### PR TITLE
feat: update node version to 18.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:18.16.1-alpine3.18
 
 LABEL maintainer="integrtr <info@integrtr.com>"
 


### PR DESCRIPTION
## Changes in this PR
- Updates the base node image to `node:18.16.1-alpine3.18`
  - https://hub.docker.com/layers/library/node/18.16.1-alpine3.18/images/sha256-bf6c61feabc1a1bd565065016abe77fa378500ec75efa67f5b04e5e5c4d447cd?context=explore